### PR TITLE
Break out titles into role and job title

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,15 @@ layout: default
     {% for page in site.pages %}
     {{ title }}
         {% if page.layout == 'jobs' %}
-          {% unless page.title contains 'Job Title' %}
+          {% unless page.title contains 'Job Title' %}{% comment %} Filter out the example page {% endcomment %}
           <li>
             <h2>
               <a class="page-link" href="{{ page.url | prepend: site.baseurl }}" title="{{ page.title }}">{{ page.title }}</a>
             </h2>
-            <p class="pill organization">{{ page.organization }}</p>
+            <p>
+              <span class="pill role">{{ page.role }}</span>,
+              <span class="pill organization">{{ page.organization }}</span>
+            </p>
             <span class="pill rate">{{ page.rate }}</span>
           </li>
           {% endunless %}

--- a/job-template.md
+++ b/job-template.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: Job Title
+title: Job Title # Try to keep it to three words
+role: Job Role # Ex: UI Designer, UX Designer, Icon Designer
 organization: Organization Name
 github: github-username
 url: http://organiaation-website.com

--- a/jobs/2015-02-okfn-frontend-developer-UX-designer.md
+++ b/jobs/2015-02-okfn-frontend-developer-UX-designer.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: Front-end Developer and UX Designer for Data-Driven Project
+title: Data-Driven Project
+role: Front-end Developer and UX Designer
 organization: OKFN
 github: okfn
 org_url: http://okfn.org

--- a/jobs/2015-03-UX-audit-and-facelift-of-Pencil.md
+++ b/jobs/2015-03-UX-audit-and-facelift-of-Pencil.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
 title: UX audit and facelift of Pencil
+role: User Experience Designer
 organization: Evolus
 github:
 org_url: http://pencil.evolus.vn

--- a/jobs/2015-03-cocoa-dev-to-opensource-espionage.md
+++ b/jobs/2015-03-cocoa-dev-to-opensource-espionage.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: Design focused Cocoa developer to open source Espionage 3
+title: open source Espionage 3
+role: Design focused Cocoa developer
 organization: Tao Effect LLC
 github: taoeffect
 org_url: https://www.espionageapp.com

--- a/jobs/2015-03-ui-design-for-raml2html-api-docs-generator.md
+++ b/jobs/2015-03-ui-design-for-raml2html-api-docs-generator.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: UI designer for raml2html
+title: raml2html UI Update
+role: UI designer
 github: kevinrenskers
 org_url: https://github.com/kevinrenskers/raml2html
 tags: interface design

--- a/jobs/chat-secure.md
+++ b/jobs/chat-secure.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
 title: Improve Chat Secure Usability
+role: Usability
 organization: The Guardian Project
 github: guardianproject
 org_url: https://guardianproject.info/apps/chatsecure/

--- a/jobs/democracy-club.md
+++ b/jobs/democracy-club.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
 title: DemocracyClub Projects
+role: Front-end Designer
 organization: DemocracyClub
 github: DemocracyClub
 org_url: https://democracyclub.org.uk/

--- a/jobs/guitarix.md
+++ b/jobs/guitarix.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: GUI Designer
+title: Create Audio Software Interface
+role: GUI Designer
 organization: guitarix
 github: brummer10
 org_url: http://guitarix.sourceforge.net/

--- a/jobs/qtpass.md
+++ b/jobs/qtpass.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
 title: QTPass
+role: UI / UX designer
 organization: IJhack
 github: ijhack
 url: http://ijhack.github.io/qtpass/
@@ -12,4 +13,4 @@ date_posted: 2015-04-22
 
 Qtpass is a multiplatform gui for the pass (passwordstore.org) password manager. It uses standard unix tools like gpg for encrypting your passwords.
 
-We are adding features and slowly approaching a usable 1.x release, however the user interface is ugly, badly arranged and unintuitive. We'd like some help with organising and redesigning the user interface and workflow so that the application is easier and nicer to use. 
+We are adding features and slowly approaching a usable 1.x release, however the user interface is ugly, badly arranged and unintuitive. We'd like some help with organising and redesigning the user interface and workflow so that the application is easier and nicer to use.

--- a/jobs/red-hat_senior-ixd.md
+++ b/jobs/red-hat_senior-ixd.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: UX Design for open source storage technologies
+title: open source storage technologies
+role: UX Design
 organization: Red Hat, Inc.
 org_url: https://redhat.com
 tags: interface design, ixd, ux, usability, design, user research, storage, visual design, HCI, human factors

--- a/jobs/yoctoproject.md
+++ b/jobs/yoctoproject.md
@@ -1,6 +1,7 @@
 ---
 layout: jobs
-title: Icon designer
+title: Design an Icon
+role: Icon designer
 organization: Yocto Project
 github: belenbarrospena
 org_url: http://yoctoproject.org


### PR DESCRIPTION
I've edited some of the job listings to break out the role from the title. This should make titles shorter, as well as making it clearer what's needed. 