### PR TITLE
Add Rake File For Automatically Creating a Job Posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [Jobs](http://opensourcedesign.net/jobs/)
 
-The goal here is to create a proper **"job board"** that pairs open source people and projects in need design work with designers who can do those tasks. 
-It will be a mixture of *both gratis as well as paying work.* 
-A job can be relatively small task to an entire project. 
+The goal here is to create a proper **"job board"** that pairs open source people and projects in need design work with designers who can do those tasks.
+It will be a mixture of *both gratis as well as paying work.*
+A job can be relatively small task to an entire project.
 I think the ideal balance would be a mixture of about:
 
 * 25% small singular tasks
@@ -14,8 +14,15 @@ I think the ideal balance would be a mixture of about:
 
 ### Submit a Job
 
-Our job submission process is being done transparently and "in the open." 
+Our job submission process is being done transparently and "in the open."
 If you work on an open source software project or community, feel free to submit a job to our job board by doing the following:
+
+- running `rake job title="Job Title" role="Role Name" org="Organization Name"
+- Opening the file that got generated in `jobs` and filling it in.
+- Submit a pull request.
+- Have a margarita or a hot chocolate
+
+or
 
 - Fork the repo
 - Copy `job-template.md` into the `jobs` folder
@@ -33,14 +40,14 @@ After those steps you will have submitted a job to the OSD job board ;)
 Anything related to improving O.S.D. directly. Listed in order of attainability.
 
 #### • Identity & Logo
-OSD  needs to craft an identity that is of the community and responds to the idea of open source in a clear, memorable way. 
+OSD  needs to craft an identity that is of the community and responds to the idea of open source in a clear, memorable way.
 Maybe that means the logo is something that is continuously iterated on, maybe it is something that has a consistent form that responds to changes in the greater community/world.
 
 #### • Project listing page
-What projects are currently in need of completion? 
-The current solution has been to post each project as a github issue, which might be a good solution in the short term. 
+What projects are currently in need of completion?
+The current solution has been to post each project as a github issue, which might be a good solution in the short term.
 It might be better to have an ongoing list where designers can post and up-vote freely.
 
 #### • A space on the web
-http://opensourcedesign.net redirects to Github. 
+http://opensourcedesign.net redirects to Github.
 Would it meaningfully help the community to make a site with digests of all the repos?

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,60 @@
+require "rubygems"
+require 'rake'
+require 'yaml'
+require 'time'
+require 'open-uri'
+
+SOURCE = "."
+CONFIG = {
+  'version' => "0.2.13",
+  'includes' => File.join(SOURCE, "_includes"),
+  'themes' => File.join(SOURCE, "_includes", "themes"),
+  'layouts' => File.join(SOURCE, "_layouts"),
+  'jobs' => File.join(SOURCE, "jobs"),
+  'post_ext' => "markdown",
+  'theme_package_version' => "0.1.0"
+}
+
+# Usage: rake job title="Title" org="Organization Name" role="Job Role" [date="2012-02-09"]
+desc "Create a new job in #{CONFIG['jobs']}"
+task :job do
+  abort("rake aborted: '#{CONFIG['jobs']}' directory not found.") unless FileTest.directory?(CONFIG['jobs'])
+  title = ENV['title'] || "Job Title \# Try to keep it to three words"
+  org = ENV['org'] || "Organization Name"
+  role = ENV['role'] || "Job Role \# Ex: UI Designer, UX Designer, Icon Designer"
+  slug = "#{title} - #{org}".downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+  begin
+    date = (ENV['date'] ? Time.parse(ENV['date']) : Time.now).strftime('%Y-%m-%d')
+    date_time = (ENV['date'] ? Time.parse(ENV['date']) : Time.now).strftime('%Y-%m-%d-%H-%M')
+  rescue Exception => e
+    puts "Error - date format must be YYYY-MM-DD, please check you typed it correctly!"
+    exit -1
+  end
+  cat = ENV['cat'] || ""
+
+  filename = File.join(CONFIG['jobs'], "#{date}-#{slug}.#{CONFIG['post_ext']}")
+  if File.exist?(filename)
+    abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+  end
+
+  puts "Creating new post: #{filename}"
+  open(filename, 'w') do |post|
+    post.puts "---"
+    post.puts "layout: jobs"
+    post.puts "date_posted: #{date_time}"
+    post.puts "title: \"#{title.gsub(/-/,' ')}\""
+    post.puts "role: \"#{role.gsub(/-/,' ')}\""
+    post.puts "organization: \"#{org.gsub(/-/,' ')}\""
+    post.puts "github: github-username"
+    post.puts "contributing_md: \# (optional) A link to your ocntibuting guidelines"
+    post.puts "contributors_md: \# (optional) A list of contributors who are reach-out-able"
+    post.puts "url: \# <your-org-url>"
+    post.puts "tags: \# Ex. interface design, branding, logo"
+    post.puts "status: \# Ex. searching, hired"
+    post.puts "rate: \# Ex. gratis, $60 hour, $1000 total, etc"
+    post.puts "---"
+    post.puts ""
+    post.puts "Write the description of the job here...
+"
+  end
+end # task :job


### PR DESCRIPTION
None of this copy and pasting template business anymore. It got borked a couple of times in the past.

Just run 

`rake job title="Designing CodeOfConductLink Site" role="UI Designer" org="Code of Conduct Link"`

And it will automatically create a file in the `jobs` folder.

# What's Changed
* Added a Rake file to automatically create job files based on certain listings
* Added that to the Readme (While I was in there my editor removed trailing spaces). 