### PR TITLE
Use OpenScore email instead of contact page

### DIFF
--- a/jobs/2017-01-23-Graphic designer for OpenScore.md
+++ b/jobs/2017-01-23-Graphic designer for OpenScore.md
@@ -8,16 +8,12 @@ org_url: 'https://musescore.org/en/user/57401/blog/2017/01/11/introducing-opensc
 title: Graphic designer for OpenScore
 rate: paid
 skills: "OpenScore logo\r\nGraphics for communications (videos, presentations, blog posts, etc.)"
-how_to_apply:
-  - >-
-    Contact via this page with links to a CV or portfolio:
-    https://musescore.com/shoogle/contact
-  - "https://fosdem.org/2017/schedule/event/openscore/\r\nhttps://musescore.org/\r\nhttp://imslp.org/"
+how_to_apply: Email openscore@musescore.com with links to CV and portfolio.
 tags: 'music, open data, creative commons, crowdfund, crowdsource, accessibility'
 date: '2017-01-24T12:20:58.454Z'
 ---
-OpenScore is a collaboration between MuseScore, IMSLP, and various other partners across the music and tech industries. The aim is to unite MuseScore’s millions of users in a crowdsource effort digitise and liberate the works of Mozart, Beethoven and other famous classical composers.
+OpenScore is a collaboration between [MuseScore](https://musescore.org/), [IMSLP](http://imslp.org/), and various other partners across the music and tech industries. The aim is to unite MuseScore’s millions of users in a crowdsource effort digitise and liberate the works of Mozart, Beethoven and other famous classical composers.
 
 Digital sheet music provides convenient sharing, adaptation and playback across a range of devices, including computers, phones and tablets. The scores will be made available in a variety of formats, including PDF, MIDI and MusicXML, as well as accessible formats like Braille and Modified Stave Notation for blind and partially sighted musicians. The scores will be released under a Creative Commons license to remove all copyright restrictions. This will be of huge benefit to orchestras, choirs and individuals looking for materials from which to practise music. It will also facilitate a number of uses in research, academia, and education, and help to inspire composers and arrangers in producing new content.
 
-OpenScore will be running a Kickstarter campaign to fund the transcription effort, and we will be seeking to raise its profile at a number of upcoming music and tech conferences. We are looking for a designer who is familiar with open source and Creative Commons, and who can help us to illustrate these concepts in a way the general public can understand.
+OpenScore will be running a Kickstarter campaign to fund the transcription effort, and we will be seeking to raise its profile at a number of upcoming music and tech [conferences](https://fosdem.org/2017/schedule/event/openscore/). We are looking for a designer who is familiar with open source and Creative Commons, and who can help us to illustrate these concepts in a way the general public can understand.


### PR DESCRIPTION
- Use email instead of contact page (contact page required sign-in)
- Fix badly formatted links.