### PR TITLE
Review job submission form wording

### DIFF
--- a/job-form.html
+++ b/job-form.html
@@ -15,7 +15,7 @@ permalink: /job-form/
 some design help, let the Open Source Design community know that you are looking
 for design contributions or to hire a designer. Your posting will be displayed on our <a
 href="/jobs/">jobs page</a>.</p>
-	<p class="lead"><a href="http://opensourcedesign.net/code-of-conduct/">We have a code of conduct</a>. Consider reading it before submitting your job.</p>
+	<p class="lead"><a href="http://opensourcedesign.net/code-of-conduct/">We have a code of conduct</a>. Please read it before submitting your job.</p>
 	<form method="POST" action="https://api.staticman.net/v2/entry/opensourcedesign/jobs/gh-pages/jobs">
 	  <input name="options[redirect]" type="hidden" value="http://opensourcedesign.net/jobs/thank-you/">
 	  <input name="fields[status]" type="hidden" value="searching">
@@ -28,24 +28,22 @@ href="/jobs/">jobs page</a>.</p>
 		<input type="text" class="form-control" id="role" placeholder="E.g. Graphic designer" required>
 	  </div-->
 	  <fieldset>
-		<legend>About you</legend>
+		<legend>About your project</legend>
 		<div class="form-group">
-		  <label for="organization">Organisation</label>
-		  <p class="help-block">The name of your company, organisation or project.</p>
+		  <label for="organization">Project name</label>
 		  <input type="text"
 			class="form-control"
 			id="organization"
-			placeholder="E.g. AcmeProjects"
+			placeholder="e.g. AcmeProjects"
 			name="fields[organization]"
 			required>
 		</div>
 		<div class="form-group">
-		  <label for="org_url">Organisation's URL</label>
-		  <p class="help-block">A link to the organisation you entered above.</p>
+		  <label for="org_url">Project website</label>
 		  <input type="url"
 			class="form-control"
 			id="org_url"
-			placeholder="E.g. https://www.acmeprojects.org"
+			placeholder="e.g. https://acmeprojects.org"
 			name="fields[org_url]"
 			required>
 		</div>
@@ -53,29 +51,26 @@ href="/jobs/">jobs page</a>.</p>
 	  <fieldset>
 		<legend>About the job</legend>
 		<div class="form-group">
-		  <label for="title">Job title</label>
-		  <p class="help-block">This will be the main heading in your job's page. Make it specific, but not too long. You could include a role and the name of your project.</p>
+		  <label for="title">Post title</label>
+		  <p class="help-block">This will be the main heading in your job's page. Make it specific, but not too long.</p>
 		  <input type="text"
 			class="form-control"
 			id="title"
-			placeholder="E.g. Graphic designer for OpenAcme"
+			placeholder="e.g. Design review of our app"
 			name="fields[title]"
 			required>
 		</div>
 		<div class="form-group">
-		  <label for="role">Job role</label>
-		  <p class="help-block">What role is this job? Use at most two words.</p>
+		  <label for="role">Job category</label>
 		  <input type="text"
 			class="form-control"
 			id="role"
-			placeholder="E.g. Graphic Designer"
+			placeholder="e.g. 'Logo design & branding', 'Web design', 'Interaction design', 'Usability review & research', …"
 			name="fields[role]"
 			required>
-		  <small>Some examples are "UX Designer", "UI Designer", "Graphic Designer", "Researcher", "Q&amp;A"</small>
 		</div>
 		<div class="form-group">
 		  <label>Compensation</label>
-		  <p class="help-block">The type of remuneration on offer.</p>
 		  <div class="radio">
 			<label>
 			  <input type="radio"
@@ -83,7 +78,7 @@ href="/jobs/">jobs page</a>.</p>
 				id="gratis"
 				value="gratis"
 				checked>
-			  Gratis (we can't pay)
+			  Gratis – we are all volunteers
 			</label>
 		  </div>
 		  <div class="radio">
@@ -92,7 +87,7 @@ href="/jobs/">jobs page</a>.</p>
 				name="fields[compensation]"
 				id="paid"
 				value="paid">
-			  Paid (yes, we can pay!)
+			  Paid – yes, we can pay!
 			</label>
 		  </div>
 		</div>
@@ -105,16 +100,19 @@ href="/jobs/">jobs page</a>.</p>
 		  <input type="text"
 			class="form-control"
 			id="fields[paid_details]"
-			placeholder="E.g. USD 5000 fixed rate"
+			placeholder="e.g. USD 5000 fixed rate"
 			name="paid_details">
 		</div>
 		<div class="form-group">
 		  <label for="description">Job description</label>
-		  <p class="help-block">Include a brief introduction to your project, and explain the design work needed.</p>
+		  <p class="help-block">Start with a one-line introduction to your project, and then explain the design work needed.</p>
 		  <textarea class="form-control"
 			id="description"
 			rows="5"
 			name="fields[description]"
+			placeholder="e.g. AcmeProjects is a …
+
+			We need some design review of our mobile app …"
 			required></textarea>
 		  <small>Markdown is okay</small>
 		</div>
@@ -123,20 +121,22 @@ href="/jobs/">jobs page</a>.</p>
 			Deliverables
 			<small>(optional)</small>
 		  </label>
-		  <p class="help-block">If appropriate, list the things you expect the designer to deliver. For example: a logo and a set of icons.</p>
+		  <p class="help-block">If appropriate, list the things you expect the designer to deliver.</p>
 		  <textarea class="form-control"
 			id="skills"
-			rows="5"
-			name="fields[skills]"></textarea>
+			rows="3"
+			name="fields[skills]"
+			placeholder="e.g. A logo & a set of icons, or a usability review document"></textarea>
 		  <small>Markdown is okay</small>
 		</div>
 		<div class="form-group">
-		  <label for="how_to_apply">How to apply</label>
-		  <p class="help-block">How to express interest on the job. At minimum, include contact information. If you would like to see a CV or a portfolio, say so.</p>
+		  <label for="how_to_apply">Contact person</label>
+		  <p class="help-block">Who to contact to get involved with design. Please include some sort of personal handle who the designer can communicate with to get started out.</p>
 		  <textarea class="form-control"
 			id="how_to_apply"
-			rows="5"
+			rows="3"
 			required
+			placeholder="Jane (lead dev) <jane@acmeprojects.org>"
 			name="fields[how_to_apply]"></textarea>
 		  <small>Markdown is okay</small>
 		</div>
@@ -145,10 +145,10 @@ href="/jobs/">jobs page</a>.</p>
 			Relevant links
 			<small>(optional)</small>
 		  </label>
-		  <p class="help-block">Things like source code repositories, existing design work, project wiki or blog, etc.</p>
+		  <p class="help-block">Things like contribution page, existing design work, project wiki or blog, etc.</p>
 		  <textarea class="form-control"
 			id="links"
-			rows="5"
+			rows="3"
 			name="fields[how_to_apply]"></textarea>
 		</div>
 		<div class="form-group">
@@ -160,7 +160,7 @@ href="/jobs/">jobs page</a>.</p>
 		  <textarea class="form-control"
 			id="tags"
 			rows="2"
-			placeholder="E.g. logo, branding, graphic design"
+			placeholder="e.g. logo, branding, graphic design"
 			name="fields[tags]"></textarea>
 		</div>
 	  </fieldset>


### PR DESCRIPTION
Mostly this is just simplifying the text and clarifying better what it is. For example »Job title« was confusing because it sounds like the title you have at a full-time job, whereas it’s simply the title of the posting.

The bigger change here is the move from a generic »How to apply« towards a specific »Contact person«. And we should absolutely require that. Because for some jobs there are public mailing lists or simply the bug tracker listed – non-open-source people do not know what to make of this. :)

We worked through this at the Berlin meetup with @jdittrich @guiguru @HeikoTietze 

Please review @simonv3 @belenbarrospena @bnvk 