### PR TITLE
Add FL/OSS language + explanation

### DIFF
--- a/job-form.html
+++ b/job-form.html
@@ -8,7 +8,7 @@ permalink: /job-form/
   <div class="row">
 	<div class="col-md-10 col-md-offset-1">
 	<h1>Submit a Job</h1>
-	<p class="lead">If you work on a free / open source project and you need
+	<p class="lead">If you work on a <a href="#floss" title="Free as in Speech (and maybe Beer)">Free/Libre and Open Source<sup>*</sup></a> project and you need
 some design help, let the Open Source Design community know that you are looking
 for design contributions or to hire a designer. Your posting will be displayed on our <a
 href="/jobs/">jobs page</a>.</p>
@@ -161,6 +161,18 @@ href="/jobs/">jobs page</a>.</p>
 	  </fieldset>
 	  <button type="submit" href="thankyou.html" class="btn btn-primary btn-lg">Submit your job to Open Source Design</button>
 	</form>
+		<div id="floss">
+			<p class='help-block'>
+				<sup>*</sup> <em>“Free software”</em> means software that respects users' freedom and community. 
+				Roughly, it means that the users have the freedom to run, copy, distribute, study, 
+				change and improve the software. Thus, “free software” is a matter of liberty, not price. 
+				To understand the concept, you should think of “free” as in “free speech,” 
+				not as in “free beer”. We sometimes call it “libre software,” 
+				borrowing the French or Spanish word for “free” as in freedom, 
+				to show we do not mean the software is gratis.
+				(<a href="https://www.gnu.org/philosophy/free-sw.en.html" title="What is Free Software at GNU.org">more</a>)
+			</p>
+		</div>
 	</div>
   </div>
 </div>


### PR DESCRIPTION
This addresses opensourcedesign/opensourcedesign.github.io#157 by adding the full "Free/Libre and Open Source" moniker, as well as a link to a descriptive paragraph at the end of the page with a more direct explanation (+ links to GNU.org Free Software definition).