### PR TITLE
Missing menu entries when going to Jobs, Events #167

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,9 @@
                 <i class="fa fa-bars"></i>
             </button>
             <a class="navbar-brand page-scroll" href="/#page-top">
-                <span class="logo">{% include img/opensourcedesign-logo.svg %}</span>
+                <span class="logo">
+                    <img src="//opensourcedesign.net/images/opensourcedesign-logo.svg" class="logo" alt="Open Source Design Logo"/>
+                </span>
                 Open Source Design
             </a>
         </div>


### PR DESCRIPTION
Fixing build: "A file was included in `/_layouts/default.html` that is a symlink or does not exist in your `_includes` directory"