### PR TITLE
Fix YAML Exception on building site

### DIFF
--- a/jobs/2019-06-28-mockups-for-the-dry-python-project.md
+++ b/jobs/2019-06-28-mockups-for-the-dry-python-project.md
@@ -4,7 +4,7 @@ layout: jobs
 title: dry-python
 role: UI Designer
 organization: dry-python
-github: @dry-python
+github: dry-python
 contact: dry.python.org@gmail.com
 contributing_md:
 contributors_md:


### PR DESCRIPTION
When building the site via `bundler exec jekyll serve --watch --config _config.yml,_config-dev.yml`, there was this error:
```
YAML Exception reading
opensourcedesign.github.io/jobs/jobs/2019-06-28-mockups-for-the-dry-python-project.md:
(<unknown>): found character that cannot start any token
while scanning for the next token at line 7 column 9
```

This fixes the issue. :)