### PR TITLE
Add github_handle as an allowable field

### DIFF
--- a/staticman.yml
+++ b/staticman.yml
@@ -10,7 +10,7 @@ jobs:
   allowedFields: ["organization", "org_url", "compensation",
                   "paid_details", "title", "description", "deliverables",
                   "how_to_apply", "links", "tags", "status", "date_posted",
-                  "layout", "rate", "role"]
+                  "layout", "rate", "role", "github_handle"]
 
   # (*) REQUIRED WHEN USING NOTIFICATIONS
   #


### PR DESCRIPTION
Possible fix for issue https://github.com/opensourcedesign/opensourcedesign.github.io/issues/321 - "Bug when inputting GitHub handle" and maybe https://github.com/opensourcedesign/opensourcedesign.github.io/issues/119 also.
