### PR TITLE
Removes jobs redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,6 @@
 ---
 layout: default
 title: Jobs
-redirect_to:
-  - https://discourse.opensourcedesign.net/t/post-jobs-on-the-discourse-forum-for-now/3416
 ---
 
 <div class="container">
@@ -14,7 +12,7 @@ redirect_to:
     <div class="row">
         <div class="col-md-5">
           <p>
-            Need a logo designed, a usability study, or an interface-facelift? 
+            Need a logo designed, a usability study, or an interface-facelift?
             Our diverse community and extended network have got you covered.
           <p>
         </div>


### PR DESCRIPTION
The jobs form has now been fixed. This PR removes the temporary redirect that was added to the discourse post.