### PR TITLE
Changed global.yml file to fix different nav-bar links on jobs page

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -5,11 +5,14 @@ header_links:
     url: /articles/
   - name: Resources
     url: /resources/
-  - name: Projects
-    url: /projects/
   - name: Jobs
     url: /jobs/
   - name: Events
     url: /events/
   - name: Forum
     url: https://discourse.opensourcedesign.net/
+  - name: Summit
+    url: /summit
+  - name: Milestones
+    url: /milestones
+


### PR DESCRIPTION
"Jobs" webpage had a different repository (jobs) than the other pages which were inside opensourcedesign.github.io.
I changed the global.yml file in Jobs repository to match the one in opensourcedesign.github.io. The Jobs webpage should now have same nav-bar links as in other pages