### PR TITLE
Fix invalid YAML in old job post

### DIFF
--- a/jobs/2021-02-07-design-contributors-wanted.md
+++ b/jobs/2021-02-07-design-contributors-wanted.md
@@ -5,7 +5,7 @@ date_posted: '2021-02-07'
 layout: jobs
 organization: Open Food Network
 org_url: 'https://www.openfoodnetwork.org/'
-title: Design contributors for Open Food Systems platform: UX, research, UI, Visual Design, build your own project etc.
+title: 'Design contributors for Open Food Systems platform: UX, research, UI, Visual Design, build your own project etc.'
 role: 'User research, interaction design, visual design'
 compensation: gratis
 deliverables: ''


### PR DESCRIPTION
Fix #949. The second colon on this line (i.e. 'platform:') was causing issues for the YAML interpreter.

```
...
title: Design contributors for Open Food Systems platform: UX, research, UI, Visual Design, build your own project etc.
...
```

...so I just wrap the whole line in quotes as surrounding lines have been.