### PR TITLE
feat: Add mandatory license field to job submission form

### DIFF
--- a/job-form.html
+++ b/job-form.html
@@ -181,12 +181,12 @@ href="/jobs/">jobs page</a>.</p>
 	</form>
 		<div id="floss">
 			<p class='help-block'>
-				<sup>*</sup> <em>"Free software"</em> means software that respects users' freedom and community.
+				<sup>*</sup> <em>“Free software”</em> means software that respects users' freedom and community.
 				Roughly, it means that the users have the freedom to run, copy, distribute, study,
-				change and improve the software. Thus, "free software" is a matter of liberty, not price.
-				To understand the concept, you should think of "free" as in "free speech,"
-				not as in "free beer". We sometimes call it "libre software,"
-				borrowing the French or Spanish word for "free" as in freedom,
+				change and improve the software. Thus, “free software” is a matter of liberty, not price.
+				To understand the concept, you should think of “free” as in “free speech,”
+				not as in “free beer”. We sometimes call it “libre software,”
+				borrowing the French or Spanish word for “free” as in freedom,
 				to show we do not mean the software is gratis.
 				(<a href="https://www.gnu.org/philosophy/free-sw.en.html" title="What is Free Software at GNU.org">more</a>)
 			</p>

--- a/job-form.html
+++ b/job-form.html
@@ -47,12 +47,12 @@ href="/jobs/">jobs page</a>.</p>
 		<div class="form-group">
 		  <label for="license">Project License/s *</label>
 		  <p class="help-block">Project must have some kind of open source license publicly viewable to be accepted. You can share any kind of document e.g. link to the license in your public repo, a webpage, an online cloud document etc. We want to be sure that you are following open source principles.</p>
-		  <textarea class="form-control"
+		  <input type="url"
+			class="form-control"
 			id="license"
-			rows="3"
 			name="fields[license]"
 			placeholder="https://github.com/yourproject/LICENSE or https://yourproject.org/license"
-			required></textarea>
+			required>
 		</div>
 	  </fieldset>
 	  <fieldset>
@@ -181,12 +181,12 @@ href="/jobs/">jobs page</a>.</p>
 	</form>
 		<div id="floss">
 			<p class='help-block'>
-				<sup>*</sup> <em>“Free software”</em> means software that respects users' freedom and community.
+				<sup>*</sup> <em>"Free software"</em> means software that respects users' freedom and community.
 				Roughly, it means that the users have the freedom to run, copy, distribute, study,
-				change and improve the software. Thus, “free software” is a matter of liberty, not price.
-				To understand the concept, you should think of “free” as in “free speech,”
-				not as in “free beer”. We sometimes call it “libre software,”
-				borrowing the French or Spanish word for “free” as in freedom,
+				change and improve the software. Thus, "free software" is a matter of liberty, not price.
+				To understand the concept, you should think of "free" as in "free speech,"
+				not as in "free beer". We sometimes call it "libre software,"
+				borrowing the French or Spanish word for "free" as in freedom,
 				to show we do not mean the software is gratis.
 				(<a href="https://www.gnu.org/philosophy/free-sw.en.html" title="What is Free Software at GNU.org">more</a>)
 			</p>

--- a/job-form.html
+++ b/job-form.html
@@ -44,6 +44,16 @@ href="/jobs/">jobs page</a>.</p>
 			name="fields[org_url]"
 			required>
 		</div>
+		<div class="form-group">
+		  <label for="license">Project License/s *</label>
+		  <p class="help-block">Project must have some kind of open source license publicly viewable to be accepted. You can share any kind of document e.g. link to the license in your public repo, a webpage, an online cloud document etc. We want to be sure that you are following open source principles.</p>
+		  <textarea class="form-control"
+			id="license"
+			rows="3"
+			name="fields[license]"
+			placeholder="https://github.com/yourproject/LICENSE or https://yourproject.org/license"
+			required></textarea>
+		</div>
 	  </fieldset>
 	  <fieldset>
 		<legend>About the job</legend>
@@ -171,12 +181,12 @@ href="/jobs/">jobs page</a>.</p>
 	</form>
 		<div id="floss">
 			<p class='help-block'>
-				<sup>*</sup> <em>“Free software”</em> means software that respects users' freedom and community.
+				<sup>*</sup> <em>"Free software"</em> means software that respects users' freedom and community.
 				Roughly, it means that the users have the freedom to run, copy, distribute, study,
-				change and improve the software. Thus, “free software” is a matter of liberty, not price.
-				To understand the concept, you should think of “free” as in “free speech,”
-				not as in “free beer”. We sometimes call it “libre software,”
-				borrowing the French or Spanish word for “free” as in freedom,
+				change and improve the software. Thus, "free software" is a matter of liberty, not price.
+				To understand the concept, you should think of "free" as in "free speech,"
+				not as in "free beer". We sometimes call it "libre software,"
+				borrowing the French or Spanish word for "free" as in freedom,
 				to show we do not mean the software is gratis.
 				(<a href="https://www.gnu.org/philosophy/free-sw.en.html" title="What is Free Software at GNU.org">more</a>)
 			</p>

--- a/job-template.md
+++ b/job-template.md
@@ -9,6 +9,7 @@ contact: email, github, irc channel, etc # How can people reach out to you?
 contributing_md: (optional) # A link to your contributing guidelines for newcomers
 contributors_md: (optional) # A list of contributors who are reach-out-able.
 org_url: http://organisation-website.com
+license: http://link-to-your-license-file.com # Link to your project's open source license (required)
 tags: interface design, branding, logo
 status: searching / hired
 compensation: gratis / $60 hour / $1000 total / etc...

--- a/staticman.yml
+++ b/staticman.yml
@@ -10,7 +10,7 @@ jobs:
   allowedFields: ["organization", "org_url", "compensation",
                   "paid_details", "title", "description", "deliverables",
                   "how_to_apply", "links", "tags", "status", "date_posted",
-                  "layout", "rate", "role", "github_handle"]
+                  "layout", "rate", "role", "github_handle", "license"]
 
   # (*) REQUIRED WHEN USING NOTIFICATIONS
   #


### PR DESCRIPTION
Adds a required field for project licenses to ensure all job postings are from properly licensed open source projects. The field includes:
- Mandatory textarea for license documentation
- Help text explaining the requirement
- Support for various license documentation formats (repo links, webpages, etc.)

This change helps maintain OSD's commitment to open source principles by ensuring all job postings are from properly licensed projects.