### PR TITLE
Add warning+link to rules for responding to jobs

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -61,6 +61,9 @@ layout: default
         {{ content | markdownify }}
       </article>
 
+      <p>Please don’t use generic copy-pasted responses, they can get you banned.
+      See our <a href="https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416">guidelines</a>.</p>
+
       <div id='discourse-comments'></div>
     </div>
   </div>


### PR DESCRIPTION
Fix for https://github.com/opensourcedesign/opensourcedesign.github.io/issues/459 - added warning text:

```
Please don’t use generic copy-pasted responses, they can get you banned. See our [guidelines](https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416).
```

Looks like this:

![Screenshot From 2025-06-05 16-09-26](https://github.com/user-attachments/assets/cfdd4604-df2d-4cc4-a6e5-3cc194888701)

(ignore the black/missing discourse widget, it won't load under my dev environment)