### PR TITLE
Fix #959: Add missing Bootstrap JS to enable mobile burger menu on Jobs page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -33,6 +33,9 @@
 
 </footer>
 
+
+
+
 <script id="template-activity-item" type="text/template">
 <li class="item">
   <a href="https://github.com/<%= actor.login %>" class="avatar"><img src="<%= actor.avatar_url %>"></a>
@@ -63,3 +66,5 @@
 <script src="//opensourcedesign.net/js/jquery.min.js"></script>
 <script src="//opensourcedesign.net/js/underscore-min.js"></script>
 <script src="//opensourcedesign.net/js/site.js"></script>
+//Fix for burger menu not opening
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,8 @@
     {{ page.end_scripts }}
 
     <!-- Custom Theme JavaScript -->
-    <script src="/js/main.js"></script>
+     <!-- Removed the Line - <script src="/js/main.js"></script> Causing error in production  -->
+    
 
   </body>
 


### PR DESCRIPTION
**Description:**
This pull request addresses the issue where the mobile burger menu on the Jobs page does not open, causing poor navigation experience on mobile devices.

What was wrong?
The Jobs repo was missing the **necessary Bootstrap JavaScript dependency in the footer**, which is required to enable the burger menu toggle functionality on mobile.

What this fix does:

**_Adds the Bootstrap JS script tag (https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js) to the _includes/footer.html file in the Jobs repo._**

Removes an incorrect reference to a non-existent main.js file from the layout.

Ensures the mobile menu toggle works properly when clicking the burger icon.

How to test:

Clone the Jobs repo along with the main repo.

Run bundle install inside the Jobs repo.

Serve the site locally with bundle exec jekyll serve.

Open the Jobs page on a mobile device or use browser dev tools responsive mode.

Click the burger menu icon and confirm that the menu opens as expected.

https://github.com/user-attachments/assets/1d50c3b9-8606-4cc3-b7b6-983fddb2adb9

**Video Demonstration (Optional)**
I’ve included a short video demonstrating the issue with the burger menu on the Jobs page not opening on mobile, and how this fix resolves it.

You can see the menu not opening before the change, and working correctly after applying the fix.

If needed, I’m happy to provide more details or recordings!

Thank you for considering this fix! Looking forward to your feedback.

