### PR TITLE
Add job response guidelines link to jobs pages

### DIFF
--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -61,8 +61,10 @@ layout: default
         {{ content | markdownify }}
       </article>
 
-      <p>Please don’t use generic copy-pasted responses, they can get you banned.
-      See our <a href="https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416">guidelines</a>.</p>
+      <div class="alert alert-warning">
+        <strong>Important:</strong> Please don't use generic copy-pasted responses, they can get you banned.
+        See our <a href="https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416" target="_blank">guidelines for responding to jobs</a>.
+      </div>
 
       <div id='discourse-comments'></div>
     </div>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,15 @@ title: Jobs
           </p>
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+            <div class="alert alert-info">
+                <strong>Important:</strong> When responding to job postings, please avoid generic copy-pasted responses. 
+                See our <a href="https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416" target="_blank">guidelines for responding to jobs</a> 
+                to avoid being banned from the community.
+            </div>
+        </div>
+    </div>
     <hr>
     <div class="row">
         <div class="col-md-10 col-md-offset-1">


### PR DESCRIPTION
This PR addresses issue #459 from the main Open Source Design repository by adding prominent links to the Discourse forum guidelines for responding to job postings.

## Changes Made
- **Main jobs page** (`index.html`): Added alert box with guidelines link before job listings
- **Individual job pages** (`_layouts/jobs.html`): Enhanced existing warning with better styling and prominent alert box
- **Consistent messaging**: Both pages now warn against copy-paste responses
- **Direct link**: Points to the exact Discourse forum post: https://discourse.opensourcedesign.net/t/guidelines-on-posting-and-responding-to-jobs/3416


## Related Issue
Fixes opensourcedesign/opensourcedesign.github.io#459

## Testing
- [x] Verified links work correctly
- [x] Checked Bootstrap alert styling displays properly
- [x] Confirmed consistent messaging across both pages
- [x] No linting errors introduced

## Notes
This implementation helps reduce generic copy-paste responses by making the guidelines more visible to users browsing and responding to job postings.